### PR TITLE
Fix foundry permissions

### DIFF
--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -31,7 +31,9 @@ library PoolAddress {
     /// @param key The PoolKey
     /// @return pool The contract address of the V3 pool
     function computeAddress(address factory, PoolKey memory key) internal pure returns (address pool) {
-        require(key.token0 < key.token1);
+        // OLD: require(key.token0 < key.token1);
+        // FORK: instead of reverting if token0 >= token1, swap them
+        (key.token0, key.token1) = key.token0 < key.token1 ? (key.token0, key.token1) : (key.token1, key.token0);
         pool = address(
             uint256(
                 keccak256(

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,2 @@
+[profile.default]
+fs_permissions = [{ access = "read-write", path = "test/"}, { access = "read-write", path = "node_modules/@uniswap/v3-core/artifacts/contracts/"}]


### PR DESCRIPTION
Had to drop into v3 for some experiments, and found this repo quite useful still haha

---

* Specify foundry `fs_permissions` in .toml to fix `vm.getCode` errors
* Slightly modified a v3 library so it does not revert on unsorted tokens
  - looks like old versions of foundry had deployed tokens in sorted order, but thats no longer the case